### PR TITLE
Copy language class to <pre> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,26 @@ unified()
   .process(/* some markdown */);
 ```
 
+## FAQ
+
+<details>
+  <summary>Why does rehype-prism copy the <code>language-</code> class to the <code>&lt;pre&gt;</code> tag?</summary>
+  
+  [Prism recommends](https://prismjs.com/#basic-usage) adding the `language-` class to the `<code>` tag like this:
+
+  ```html
+  <pre><code class="language-css">p { color: red }</code></pre>
+  ```
+
+  It bases this recommendation on the HTML5 spec. However, an undocumented behavior of their JavaScript is that, in the process of highlighting the code, they also copy the `language-` class to the `<pre>` tag:
+
+  ```html
+  <pre class="language-css"><code class="language-css"><span class="token selector">p</span> <span class="token punctuation">{</span> <span class="token property">color</span><span class="token punctuation">:</span> red <span class="token punctuation">}</span></code></pre>
+  ```
+
+  This resulted in many [Prism themes](https://github.com/PrismJS/prism-themes) relying on this behavior by using CSS selectors like `pre[class*="language-"]`. So in order for people using rehype-prism to get the most out of these themes, we decided to do the same.
+</details>
+
 [Prism]: http://prismjs.com/
 
 [refractor]: https://github.com/wooorm/refractor

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -1,12 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`copies the language- class to pre tag 1`] = `"<pre class=\\"language-css\\"><code class=\\"language-css\\"></code></pre>"`;
+
 exports[`does nothing to code block without language- class 1`] = `"<pre><code>p { color: red }</code></pre>"`;
 
 exports[`finds code and highlights 1`] = `
 "<div>
   <p>foo</p>
-  <pre><code class=\\"language-css\\"><span class=\\"token selector\\">p </span><span class=\\"token punctuation\\">{</span> <span class=\\"token property\\">color</span><span class=\\"token punctuation\\">:</span> red <span class=\\"token punctuation\\">}</span></code></pre>
+  <pre class=\\"language-css\\"><code class=\\"language-css\\"><span class=\\"token selector\\">p </span><span class=\\"token punctuation\\">{</span> <span class=\\"token property\\">color</span><span class=\\"token punctuation\\">:</span> red <span class=\\"token punctuation\\">}</span></code></pre>
 </div>"
 `;
 
-exports[`with options.ignoreMissing, does nothing to code block with fake language- class 1`] = `"<pre><code class=\\"language-thisisnotalanguage\\">p { color: red }</code></pre>"`;
+exports[`with options.ignoreMissing, does nothing to code block with fake language- class 1`] = `"<pre class=\\"language-thisisnotalanguage\\"><code class=\\"language-thisisnotalanguage\\">p { color: red }</code></pre>"`;

--- a/index.js
+++ b/index.js
@@ -24,6 +24,8 @@ module.exports = options => {
 
     let result;
     try {
+      parent.properties.className = (parent.properties.className || [])
+        .concat('language-' + lang);
       result = refractor.highlight(nodeToString(node), lang);
     } catch (err) {
       if (options.ignoreMissing && /Unknown language/.test(err.message)) {

--- a/test.js
+++ b/test.js
@@ -12,6 +12,13 @@ const processHtml = (html, options) => {
     .toString();
 };
 
+test('copies the language- class to pre tag', () => {
+  const result = processHtml(dedent`
+    <pre><code class="language-css"></code></pre>
+  `);
+  expect(result).toMatchSnapshot();
+});
+
 test('finds code and highlights', () => {
   const result = processHtml(dedent`
     <div>


### PR DESCRIPTION
Continuing from: https://github.com/mdx-js/mdx/issues/221#issuecomment-419183553

This mimics the behavior of prism.js and makes it easier to use Prism themes that rely on this.

I might have overdone the documentation part 😅 but I think it's important that people become aware of this.