### PR TITLE
Support uppercase language names

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function getLanguage(node) {
 
   for (const classListItem of className) {
     if (classListItem.slice(0, 9) === 'language-') {
-      return classListItem.slice(9);
+      return classListItem.slice(9).toLowerCase();
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -29,6 +29,16 @@ test('finds code and highlights', () => {
   expect(result).toMatchSnapshot();
 });
 
+test('handles uppercase languages correctly', () => {
+  const result = processHtml(dedent`
+    <div>
+      <p>foo</p>
+      <pre><code class="language-CSS">p { color: red }</code></pre>
+    </div>
+  `);
+  expect(result).toMatchSnapshot();
+});
+
 test('does nothing to code block without language- class', () => {
   const result = processHtml(dedent`
     <pre><code>p { color: red }</code></pre>


### PR DESCRIPTION
This allows one to specify `JS` or `JavaScript` as the language name, not just the lower case variants.