### PR TITLE
update examples to address needed processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,12 @@ rehype()
 const unified = require('unified');
 const rehypeParse = require('rehype-parse');
 const rehypePrism = require('@mapbox/rehype-prism');
+const rehypeStringify = require('rehype-stringify');
 
 unified()
   .use(rehypeParse)
   .use(rehypePrism)
+  .use(rehypeStringify)
   .processSync(/* some html */);
 ```
 
@@ -72,11 +74,13 @@ const unified = require('unified');
 const remarkParse = require('remark-parse');
 const remarkRehype = require('remark-rehype');
 const rehypePrism = require('@mapbox/rehype-prism');
+const rehypeStringify = require('rehype-stringify');
 
 unified()
   .use(remarkParse)
   .use(remarkRehype)
   .use(rehypePrism)
+  .use(rehypeStringify)
   .process(/* some markdown */);
 ```
 


### PR DESCRIPTION
related to #7

Given the current [examples in the README](https://github.com/mapbox/rehype-prism#usage), e.g.
```js
const rehypePrism = require('@mapbox/rehype-prism');
const remarkParse = require('remark-parse');
const remarkRehype = require('remark-rehype');

const processedMarkdown = await unified()
  .use(remarkParse)
  .use(remarkeRhype)
  .use(rehypePrism)
  .process(markdownContents);
```

I was getting an error
```sh
Error: Cannot `process` without `Compiler`
```

Updated examples to include adding something like 
```js
.use(rehypeStringify)
```

at the end of the chain before `process` is called