### PR TITLE
Update refractor version to v4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/mapbox/rehype-prism#readme",
   "dependencies": {
     "hast-util-to-string": "^1.0.4",
-    "refractor": "^3.3.1",
+    "refractor": "^4.1.0",
     "unist-util-visit": "^2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Prismjs < 1.24 has a [security problem](https://github.com/PrismJS/prism/security/advisories/GHSA-gj77-59wh-66hg), and refractor v4.1.0 updates its dependent Prismjs to 1.24 (https://github.com/wooorm/refractor/releases/tag/4.1.0 )