### PR TITLE
feat: allow passing aliases to refractor (closes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ By default, if `{name}` does not correspond to a [language supported by refracto
 
 If you would like to silently skip `<code>` elements with invalid languages, set this option to `true`.
 
+#### options.alias
+
+Type: `Record<string, string | string[]>`.
+Default: `undefined`.
+
+Provide [aliases] to refractor to register as alternative names for a language.
+
 ## Usage
 
 Use this package [as a rehype plugin](https://github.com/rehypejs/rehype/blob/master/doc/plugins.md#using-plugins).
@@ -104,3 +111,5 @@ unified()
 [refractor]: https://github.com/wooorm/refractor
 
 [language supported by refractor]: https://github.com/wooorm/refractor#syntaxes
+
+[aliases]: https://github.com/wooorm/refractor#refractoraliasname-alias

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -18,4 +18,13 @@ exports[`handles uppercase languages correctly 1`] = `
 </div>"
 `;
 
+exports[`with options.alias it can highlight language aliases 1`] = `
+"<pre class=\\"language-vue\\">  <code class=\\"language-vue\\">
+    <span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&#x3C;</span>script</span> <span class=\\"token attr-name\\">setup</span><span class=\\"token punctuation\\">></span></span><span class=\\"token script\\"><span class=\\"token language-javascript\\">
+      <span class=\\"token keyword\\">const</span> id <span class=\\"token operator\\">=</span> <span class=\\"token number\\">7</span>
+    </span></span><span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&#x3C;/</span>script</span><span class=\\"token punctuation\\">></span></span>
+  </code>
+</pre>"
+`;
+
 exports[`with options.ignoreMissing, does nothing to code block with fake language- class 1`] = `"<pre class=\\"language-thisisnotalanguage\\"><code class=\\"language-thisisnotalanguage\\">p { color: red }</code></pre>"`;

--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ const refractor = require('refractor');
 module.exports = (options) => {
   options = options || {};
 
+  if (options.alias) {
+    refractor.alias(options.alias);
+  }
+
   return (tree) => {
     visit(tree, 'element', visitor);
   };

--- a/test.js
+++ b/test.js
@@ -61,3 +61,17 @@ test('with options.ignoreMissing, does nothing to code block with fake language-
   const result = processHtml(html, { ignoreMissing: true });
   expect(result).toMatchSnapshot();
 });
+
+test('with options.alias it can highlight language aliases', () => {
+  const html = dedent`
+    <pre>
+      <code class="language-vue">
+        &lt;script setup&gt;
+          const id = 7
+        &lt;/script&gt;
+      </code>
+    </pre>
+  `;
+  const result = processHtml(html, { alias: { markup: ['vue', 'html'] } });
+  expect(result).toMatchSnapshot();
+});


### PR DESCRIPTION
This pull request closes https://github.com/mapbox/rehype-prism/issues/6.

Support for aliases was added in `refractor` (see https://github.com/wooorm/refractor/issues/20).